### PR TITLE
feat: Add `configureScope` transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,31 @@ but only a few that have been deprecated:
 - `Handlers.ExpressRequest` → `PolymorphicRequest` (Type export)
 - `Handlers.extractRequestData` → `extractRequestData`
 
+### Use getCurrentScope() instead of configureScope()
+
+Rewrites usages of `configureScope()` to use `getCurrentScope()` instead. Note that this will rewrite this to code
+blocks, which may not be the preferred syntax in all cases, but it's the only way to make this work somewhat reliably
+with avoiding variable clashes etc.
+
+This will rewrite:
+
+```js
+Sentry.configureScope(scope => {
+  scope.setTag('ccc', 'ccc');
+  scope.setExtra('ddd', { ddd: 'ddd' });
+});
+```
+
+to
+
+```js
+{
+  const scope = Sentry.getCurrentScope();
+  scope.setTag('ccc', 'ccc');
+  scope.setExtra('ddd', { ddd: 'ddd' });
+}
+```
+
 ### Tracing Config v7>v8
 
 Rewrites `tracePropagationTargets` and `tracingOrigins` from Integration-level config to root config on `Sentry.init()`.

--- a/src/transformers/configureScope/configureScope.test.js
+++ b/src/transformers/configureScope/configureScope.test.js
@@ -70,8 +70,10 @@ function doSomething() {
     scope.setTag('ccc', 'ccc');
     scope.setExtra('ddd', { ddd: 'ddd' });
   };
-}
-`
+
+  getCurrentScope().addAttachment({ filename: 'scope.file', data: 'great content!' });
+  Sentry.getCurrentScope().addAttachment({ filename: 'scope.file', data: 'great content!' });
+}`
     );
 
     assertStringEquals(

--- a/src/transformers/configureScope/configureScope.test.js
+++ b/src/transformers/configureScope/configureScope.test.js
@@ -47,6 +47,9 @@ function orig() {
 }
 
 function doSomething() {
+  getCurrentScope().setTag('aaa', 'aaa');
+  Sentry.getCurrentScope().setTag('ccc', 'ccc');
+
   {
     const scope = getCurrentScope();
     scope.setTag('aaa', 'aaa');

--- a/src/transformers/configureScope/configureScope.test.js
+++ b/src/transformers/configureScope/configureScope.test.js
@@ -36,6 +36,7 @@ describe('transformers | configureScope', () => {
     const withImports = getDirFileContent(tmpDir, 'withImports.js');
     const withImportsTs = getDirFileContent(tmpDir, 'withImports.ts');
     const withRequire = getDirFileContent(tmpDir, 'withRequire.js');
+    const onHub = getDirFileContent(tmpDir, 'onHub.js');
 
     assertStringEquals(
       withImports,
@@ -72,6 +73,7 @@ function doSomething() {
 }
 `
     );
+
     assertStringEquals(
       withImportsTs,
       `import { getCurrentScope } from '@sentry/browser';
@@ -133,6 +135,44 @@ function doSomething() {
     const scope = Sentry.getCurrentScope();
     scope.setTag('ccc', 'ccc');
     scope.setExtra('ddd', { ddd: 'ddd' });
+  };
+}`
+    );
+
+    assertStringEquals(
+      onHub,
+      `import { getCurrentHub } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
+
+function orig() {
+  // do something
+}
+
+function doSomething() {
+  {
+    const scope = Sentry.getCurrentHub().getScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  {
+    const scope = getCurrentHub().getScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  const hub = Sentry.getCurrentHub();
+  {
+    const scope = hub.getScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  const currentHub = Sentry.getCurrentHub();
+  {
+    const scope = currentHub.getScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
   };
 }`
     );

--- a/src/transformers/configureScope/configureScope.test.js
+++ b/src/transformers/configureScope/configureScope.test.js
@@ -1,0 +1,137 @@
+import { afterEach, describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { rmSync } from 'node:fs';
+
+import { getDirFileContent, getFixturePath, makeTmpDir } from '../../../test-helpers/testPaths.js';
+import { assertStringEquals } from '../../../test-helpers/assert.js';
+
+import configureScopeTransformer from './index.js';
+
+describe('transformers | configureScope', () => {
+  let tmpDir = '';
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { force: true, recursive: true });
+      tmpDir = '';
+    }
+  });
+
+  it('has correct name', () => {
+    assert.equal(configureScopeTransformer.name, 'Use getCurrentScope() instead of configureScope()');
+  });
+
+  it('works with app without Sentry', async () => {
+    tmpDir = makeTmpDir(getFixturePath('noSentry'));
+    await configureScopeTransformer.transform([tmpDir], { filePatterns: [] });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.js');
+    assert.equal(actual1, getDirFileContent(`${process.cwd()}/test-fixtures/noSentry`, 'app.js'));
+  });
+
+  it('works with example files', async () => {
+    tmpDir = makeTmpDir(getFixturePath('configureScope'));
+    await configureScopeTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/browser' });
+
+    const withImports = getDirFileContent(tmpDir, 'withImports.js');
+    const withImportsTs = getDirFileContent(tmpDir, 'withImports.ts');
+    const withRequire = getDirFileContent(tmpDir, 'withRequire.js');
+
+    assertStringEquals(
+      withImports,
+      `import { getCurrentScope } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
+
+function orig() {
+  // do something
+}
+
+function doSomething() {
+  {
+    const scope = getCurrentScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  {
+    const scope = getCurrentScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  configureScope(orig);
+
+  {
+    const scope = Sentry.getCurrentScope();
+    scope.setTag('ccc', 'ccc');
+    scope.setExtra('ddd', { ddd: 'ddd' });
+  };
+}
+`
+    );
+    assertStringEquals(
+      withImportsTs,
+      `import { getCurrentScope } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
+
+function orig(): void {
+  // do something
+}
+
+function doSomething(): void {
+  {
+    const scope = getCurrentScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  {
+    const scope = getCurrentScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  configureScope(orig);
+
+  {
+    const scope = Sentry.getCurrentScope();
+    scope.setTag('ccc', 'ccc');
+    scope.setExtra('ddd', { ddd: 'ddd' });
+  };
+}
+`
+    );
+
+    assertStringEquals(
+      withRequire,
+      `const { getCurrentScope } = require('@sentry/browser');
+const Sentry = require('@sentry/browser');
+
+function orig() {
+  // do something
+}
+
+function doSomething() {
+  {
+    const scope = getCurrentScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  {
+    const scope = getCurrentScope();
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  };
+
+  configureScope(orig);
+
+  {
+    const scope = Sentry.getCurrentScope();
+    scope.setTag('ccc', 'ccc');
+    scope.setExtra('ddd', { ddd: 'ddd' });
+  };
+}`
+    );
+  });
+});

--- a/src/transformers/configureScope/index.js
+++ b/src/transformers/configureScope/index.js
@@ -1,0 +1,16 @@
+import path from 'path';
+import url from 'url';
+
+import { runJscodeshift } from '../../utils/jscodeshift.js';
+
+/**
+ * @type {import('types').Transformer}
+ */
+export default {
+  name: 'Use getCurrentScope() instead of configureScope()',
+  transform: async (files, options) => {
+    const transformPath = path.join(path.dirname(url.fileURLToPath(import.meta.url)), './transform.cjs');
+
+    await runJscodeshift(transformPath, files, options);
+  },
+};

--- a/src/transformers/configureScope/transform.cjs
+++ b/src/transformers/configureScope/transform.cjs
@@ -1,0 +1,128 @@
+const { hasSentryImportOrRequire, replaceImported } = require('../../utils/jscodeshift.cjs');
+const { wrapJscodeshift } = require('../../utils/dom.cjs');
+
+/**
+ * This transform converts usages of `configureScope((scope) => {})` to use `getCurrentScope()` instead.
+ *
+ * Replaces:
+ *
+ * ```
+ * configureScope((scope) => {
+ *   scope.setTag('foo', 'bar');
+ *   scope.addEventProcessor(fn);
+ * });
+ * ```
+ *
+ * with
+ *
+ * ```
+ * const scope = getCurrentScope();
+ * scope.setTag('foo', 'bar');
+ * scope.addEventProcessor(fn);
+ *
+ * @param {import('jscodeshift').FileInfo} fileInfo
+ * @param {import('jscodeshift').API} api
+ * @param {import('jscodeshift').Options & { sentry: import('types').RunOptions & {sdk: string} }} options
+ */
+module.exports = function (fileInfo, api, options) {
+  const j = api.jscodeshift;
+  const source = fileInfo.source;
+  const fileName = fileInfo.path;
+
+  return wrapJscodeshift(j, source, fileName, (j, source) => {
+    const tree = j(source);
+
+    // If no sentry import, skip it
+    if (!hasSentryImportOrRequire(source)) {
+      return undefined;
+    }
+
+    if (!source.includes('configureScope')) {
+      return undefined;
+    }
+
+    // Replace `configureScope()`
+    tree.find(j.CallExpression).forEach(path => {
+      if (path.value.callee.type !== 'Identifier' || path.value.callee.name !== 'configureScope') {
+        return;
+      }
+
+      const callbackFn = path.value.arguments[0];
+      if (callbackFn.type !== 'ArrowFunctionExpression' && callbackFn.type !== 'FunctionExpression') {
+        return;
+      }
+
+      // The var name of the scope callback, e.g. (scope) => {} would be "scope"
+      const scopeVarName = callbackFn.params[0]?.type === 'Identifier' ? callbackFn.params[0].name : undefined;
+
+      if (!scopeVarName) {
+        return;
+      }
+
+      const callbackBody = callbackFn.body;
+
+      if (callbackBody.type !== 'BlockStatement') {
+        return;
+      }
+
+      path.replace(
+        j.blockStatement([
+          j.variableDeclaration('const', [
+            j.variableDeclarator(j.identifier(scopeVarName), j.callExpression(j.identifier('getCurrentScope'), [])),
+          ]),
+          ...callbackBody.body,
+        ])
+      );
+    });
+
+    // Replace e.g. `SentryUtuils.configureScope()`
+    tree.find(j.CallExpression).forEach(path => {
+      if (
+        path.value.callee.type !== 'MemberExpression' ||
+        path.value.callee.property.type !== 'Identifier' ||
+        path.value.callee.property.name !== 'configureScope'
+      ) {
+        return;
+      }
+
+      const calleeObj = path.value.callee.object;
+
+      const callbackFn = path.value.arguments[0];
+      if (callbackFn.type !== 'ArrowFunctionExpression' && callbackFn.type !== 'FunctionExpression') {
+        return;
+      }
+
+      // The var name of the scope callback, e.g. (scope) => {} would be "scope"
+      const scopeVarName = callbackFn.params[0]?.type === 'Identifier' ? callbackFn.params[0].name : undefined;
+
+      if (!scopeVarName) {
+        return;
+      }
+
+      const callbackBody = callbackFn.body;
+
+      if (callbackBody.type !== 'BlockStatement') {
+        return;
+      }
+
+      path.replace(
+        j.blockStatement([
+          j.variableDeclaration('const', [
+            j.variableDeclarator(
+              j.identifier(scopeVarName),
+              j.memberExpression(calleeObj, j.callExpression(j.identifier('getCurrentScope'), []))
+            ),
+          ]),
+          ...callbackBody.body,
+        ])
+      );
+    });
+
+    const sdk = options.sentry?.sdk;
+    if (sdk) {
+      replaceImported(j, tree, source, sdk, new Map([['configureScope', 'getCurrentScope']]));
+    }
+
+    return tree.toSource();
+  });
+};

--- a/test-fixtures/configureScope/onHub.js
+++ b/test-fixtures/configureScope/onHub.js
@@ -1,0 +1,30 @@
+import { getCurrentHub } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
+
+function orig() {
+  // do something
+}
+
+function doSomething() {
+  Sentry.getCurrentHub().configureScope((scope) => {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  getCurrentHub().configureScope((scope) => {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  const hub = Sentry.getCurrentHub();
+  hub.configureScope((scope) => {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  const currentHub = Sentry.getCurrentHub();
+  currentHub.configureScope((scope) => {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+}

--- a/test-fixtures/configureScope/withImports.js
+++ b/test-fixtures/configureScope/withImports.js
@@ -8,6 +8,13 @@ function orig() {
 function doSomething() {
   configureScope((scope) => {
     scope.setTag('aaa', 'aaa');
+  });
+  Sentry.configureScope((scope) => {
+    scope.setTag('ccc', 'ccc');
+  });
+
+  configureScope((scope) => {
+    scope.setTag('aaa', 'aaa');
     scope.setExtra('bbb', { bbb: 'bbb' });
   });
 

--- a/test-fixtures/configureScope/withImports.js
+++ b/test-fixtures/configureScope/withImports.js
@@ -1,0 +1,25 @@
+import { configureScope } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
+
+function orig() {
+  // do something
+}
+
+function doSomething() {
+  configureScope((scope) => {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  configureScope(function (scope) {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  configureScope(orig);
+
+  Sentry.configureScope((scope) => {
+    scope.setTag('ccc', 'ccc');
+    scope.setExtra('ddd', { ddd: 'ddd' });
+  });
+}

--- a/test-fixtures/configureScope/withImports.js
+++ b/test-fixtures/configureScope/withImports.js
@@ -29,4 +29,7 @@ function doSomething() {
     scope.setTag('ccc', 'ccc');
     scope.setExtra('ddd', { ddd: 'ddd' });
   });
+
+  configureScope(scope => scope.addAttachment({ filename: 'scope.file', data: 'great content!' }));
+  Sentry.configureScope(scope => scope.addAttachment({ filename: 'scope.file', data: 'great content!' }));
 }

--- a/test-fixtures/configureScope/withImports.ts
+++ b/test-fixtures/configureScope/withImports.ts
@@ -1,0 +1,25 @@
+import { configureScope } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
+
+function orig(): void {
+  // do something
+}
+
+function doSomething(): void {
+  configureScope((scope) => {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  configureScope(function (scope) {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  configureScope(orig);
+
+  Sentry.configureScope((scope) => {
+    scope.setTag('ccc', 'ccc');
+    scope.setExtra('ddd', { ddd: 'ddd' });
+  });
+}

--- a/test-fixtures/configureScope/withRequire.js
+++ b/test-fixtures/configureScope/withRequire.js
@@ -1,0 +1,25 @@
+const { configureScope } = require('@sentry/browser');
+const Sentry = require('@sentry/browser');
+
+function orig() {
+  // do something
+}
+
+function doSomething() {
+  configureScope((scope) => {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  configureScope(function (scope) {
+    scope.setTag('aaa', 'aaa');
+    scope.setExtra('bbb', { bbb: 'bbb' });
+  });
+
+  configureScope(orig);
+
+  Sentry.configureScope((scope) => {
+    scope.setTag('ccc', 'ccc');
+    scope.setExtra('ddd', { ddd: 'ddd' });
+  });
+}


### PR DESCRIPTION
Rewrites usages of `configureScope()` to use `getCurrentScope()` instead. Note that this will rewrite this to code
blocks, which may not be the preferred syntax in all cases, but it's the only way to make this work somewhat reliably
with avoiding variable clashes etc.

This will rewrite:

```js
Sentry.configureScope(scope => {
  scope.setTag('ccc', 'ccc');
  scope.setExtra('ddd', { ddd: 'ddd' });
});
```

to

```js
{
  const scope = Sentry.getCurrentScope();
  scope.setTag('ccc', 'ccc');
  scope.setExtra('ddd', { ddd: 'ddd' });
}
```