### PR TITLE
fix: Avoid adding comments multiple times & touching unchanged files

### DIFF
--- a/src/transformers/addMigrationComments/addMigrationComments.test.js
+++ b/src/transformers/addMigrationComments/addMigrationComments.test.js
@@ -168,4 +168,35 @@ function doSomethingElse() {
 }`
     );
   });
+
+  it('avoids adding duplicate comments', async () => {
+    tmpDir = makeTmpDir(getFixturePath('addMigrationComments'));
+    const file = 'existingComments.js';
+    const files = [`${tmpDir}/${file}`];
+    await tracingConfigTransformer.transform(files, { filePatterns: [] });
+
+    const actual = getDirFileContent(tmpDir, file);
+
+    assertStringEquals(
+      actual,
+      `import * as Sentry from '@sentry/browser';
+import { startTransaction } from '@sentry/browser';
+
+function doSomething() {
+  // TODO(sentry): Use \`startInactiveSpan()\` instead - see https://github.com/getsentry/sentry-javascript/blob/develop/docs/v8-new-performance-apis.md
+  startTransaction();
+}
+
+function doSomethingElse() {
+  // TODO(sentry): Use \`startInactiveSpan()\` instead - see https://github.com/getsentry/sentry-javascript/blob/develop/docs/v8-new-performance-apis.md
+  const transaction = Sentry.startTransaction();
+  transaction.finish();
+
+  const obj = {
+    // TODO(sentry): Use \`startInactiveSpan()\` instead - see https://github.com/getsentry/sentry-javascript/blob/develop/docs/v8-new-performance-apis.md
+    transaction: Sentry.startTransaction(),
+  };
+}`
+    );
+  });
 });

--- a/test-fixtures/addMigrationComments/existingComments.js
+++ b/test-fixtures/addMigrationComments/existingComments.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+import { startTransaction } from '@sentry/browser';
+
+function doSomething() {
+  // TODO(sentry): Use `startInactiveSpan()` instead - see https://github.com/getsentry/sentry-javascript/blob/develop/docs/v8-new-performance-apis.md
+  startTransaction();
+}
+
+function doSomethingElse() {
+  // TODO(sentry): Use `startInactiveSpan()` instead - see https://github.com/getsentry/sentry-javascript/blob/develop/docs/v8-new-performance-apis.md
+  const transaction = Sentry.startTransaction();
+  transaction.finish();
+
+  const obj = {
+    // TODO(sentry): Use `startInactiveSpan()` instead - see https://github.com/getsentry/sentry-javascript/blob/develop/docs/v8-new-performance-apis.md
+    transaction: Sentry.startTransaction(),
+  };
+}


### PR DESCRIPTION
This can become annoying if you run migr8 multiple times (e.g. we have new transformers, ...).