### PR TITLE
feat: Add transform for hub methods

### DIFF
--- a/src/transformers/hub/hub.test.js
+++ b/src/transformers/hub/hub.test.js
@@ -1,0 +1,225 @@
+import { afterEach, describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { rmSync } from 'node:fs';
+
+import { getDirFileContent, getFixturePath, makeTmpDir } from '../../../test-helpers/testPaths.js';
+import { assertStringEquals } from '../../../test-helpers/assert.js';
+
+import transformer from './index.js';
+
+describe('transformers | hub', () => {
+  let tmpDir = '';
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { force: true, recursive: true });
+      tmpDir = '';
+    }
+  });
+
+  it('has correct name', () => {
+    assert.equal(transformer.name, 'Migrate Hub usage');
+  });
+
+  it('works with app without Sentry', async () => {
+    tmpDir = makeTmpDir(getFixturePath('noSentry'));
+    await transformer.transform([tmpDir], { filePatterns: [] });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.js');
+    assert.equal(actual1, getDirFileContent(`${process.cwd()}/test-fixtures/noSentry`, 'app.js'));
+  });
+
+  it('works with imports', async () => {
+    tmpDir = makeTmpDir(getFixturePath('hub'));
+    await transformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/browser' });
+
+    const withImports = getDirFileContent(tmpDir, 'withImports.js');
+
+    assertStringEquals(
+      withImports,
+      `import {
+  captureException,
+  setUser,
+  getClient,
+  getCurrentScope,
+  getIsolationScope,
+  captureSession,
+  startSession,
+  endSession,
+  withScope,
+  setExtra,
+  setContext,
+  getIntegration,
+  captureEvent,
+} from '@sentry/browser';
+
+function doSomething() {
+  captureException(error);
+  setUser({ name: 'Anne' });
+  const client = getClient();
+  const scope = getCurrentScope();
+  const isolationScope = getIsolationScope();
+  captureSession({});
+  startSession();
+  endSession();
+  // TODO(sentry): Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub
+  getCurrentHub().run(() => {
+    // do something
+  });
+  withScope(scope => {
+    // do something
+  });
+  setExtra({});
+  setContext({});
+  const integration = getIntegration('MyIntegration');
+
+  // TODO(sentry): Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub
+  getCurrentHub().bindClient(client);
+  // TODO(sentry): Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub
+  const scope2 = getCurrentHub().pushScope();
+  // TODO(sentry): Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub
+  getCurrentHub().popScope();
+}
+
+function doSomethingElse() {
+  const hub = getCurrentHub();
+  const otherHubHere = getCurrentHub();
+
+  setExtra({});
+  captureEvent({});
+}`
+    );
+  });
+
+  it('works with require', async () => {
+    tmpDir = makeTmpDir(getFixturePath('hub'));
+    await transformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/browser' });
+
+    const actual = getDirFileContent(tmpDir, 'withRequire.js');
+
+    assertStringEquals(
+      actual,
+      `const {
+  captureException,
+  setUser,
+  getClient,
+  getCurrentScope,
+  getIsolationScope,
+  captureSession,
+  startSession,
+  endSession,
+  withScope,
+  setExtra,
+  setContext,
+  getIntegration,
+  captureEvent
+} = require('@sentry/browser');
+
+function doSomething() {
+  captureException(error);
+  setUser({ name: 'Anne' });
+  const client = getClient();
+  const scope = getCurrentScope();
+  const isolationScope = getIsolationScope();
+  captureSession({});
+  startSession();
+  endSession();
+  // TODO(sentry): Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub
+  getCurrentHub().run(() => {
+    // do something
+  });
+  withScope(scope => {
+    // do something
+  });
+  setExtra({});
+  setContext({});
+  const integration = getIntegration('MyIntegration');
+
+  // TODO(sentry): Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub
+  getCurrentHub().bindClient(client);
+  // TODO(sentry): Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub
+  const scope2 = getCurrentHub().pushScope();
+  // TODO(sentry): Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub
+  getCurrentHub().popScope();
+}
+
+function doSomethingElse() {
+  const hub = getCurrentHub();
+  const otherHubHere = getCurrentHub();
+
+  setExtra({});
+  captureEvent({});
+}`
+    );
+  });
+
+  it('works with merged imports', async () => {
+    tmpDir = makeTmpDir(getFixturePath('hub'));
+    await transformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/browser' });
+
+    const withImports = getDirFileContent(tmpDir, 'mergeImports.js');
+
+    assertStringEquals(
+      withImports,
+      `import * as Sentry from '@sentry/browser';
+
+function doSomething() {
+  Sentry.captureException(error);
+  Sentry.setUser({ name: 'Anne' });
+}`
+    );
+  });
+
+  it('works with merged requires', async () => {
+    tmpDir = makeTmpDir(getFixturePath('hub'));
+    await transformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/browser' });
+
+    const withImports = getDirFileContent(tmpDir, 'mergeRequire.js');
+
+    assertStringEquals(
+      withImports,
+      `const { captureException } = require('@sentry/browser');
+const Sentry = require('@sentry/browser');
+
+function doSomething() {
+  captureException(error);
+  Sentry.setUser({ name: 'Anne' });
+}
+`
+    );
+  });
+
+  it('works with namespace imports', async () => {
+    tmpDir = makeTmpDir(getFixturePath('hub'));
+    await transformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/browser' });
+
+    const withImports = getDirFileContent(tmpDir, 'namespaceImport.js');
+
+    assertStringEquals(
+      withImports,
+      `import * as Sentry from '@sentry/browser';
+
+function doSomething() {
+  Sentry.captureException(error);
+  Sentry.setUser({ name: 'Anne' });
+}`
+    );
+  });
+
+  it('works with namespace requires', async () => {
+    tmpDir = makeTmpDir(getFixturePath('hub'));
+    await transformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/browser' });
+
+    const withImports = getDirFileContent(tmpDir, 'namespaceRequire.js');
+
+    assertStringEquals(
+      withImports,
+      `const Sentry = require('@sentry/browser');
+
+function doSomething() {
+  Sentry.captureException(error);
+  Sentry.setUser({ name: 'Anne' });
+}`
+    );
+  });
+});

--- a/src/transformers/hub/index.js
+++ b/src/transformers/hub/index.js
@@ -1,0 +1,16 @@
+import path from 'path';
+import url from 'url';
+
+import { runJscodeshift } from '../../utils/jscodeshift.js';
+
+/**
+ * @type {import('types').Transformer}
+ */
+export default {
+  name: 'Migrate Hub usage',
+  transform: async (files, options) => {
+    const transformPath = path.join(path.dirname(url.fileURLToPath(import.meta.url)), './transform.cjs');
+
+    await runJscodeshift(transformPath, files, options);
+  },
+};

--- a/src/transformers/hub/transform.cjs
+++ b/src/transformers/hub/transform.cjs
@@ -1,0 +1,128 @@
+const { addTodoComment, modifyImports, dedupeImportStatements } = require('../../utils/jscodeshift.cjs');
+const { wrapJscodeshift } = require('../../utils/dom.cjs');
+
+/**
+ * This transform converts usages of hub APIs to use global APIs instead.
+ *
+ * Messages for:
+ * hub.bindClient()
+ * hub.pushScope()
+ * hub.popScope()
+ *
+ * @param {import('jscodeshift').FileInfo} fileInfo
+ * @param {import('jscodeshift').API} api
+ * @param {import('jscodeshift').Options & { sentry: import('types').RunOptions & {sdk: string} }} options
+ */
+module.exports = function (fileInfo, api, options) {
+  const j = api.jscodeshift;
+  const source = fileInfo.source;
+  const fileName = fileInfo.path;
+
+  const hubMethodMap = new Map([
+    ['withScope', 'withScope'],
+    ['getClient', 'getClient'],
+    ['getScope', 'getCurrentScope'],
+    ['getIsolationScope', 'getIsolationScope'],
+    ['captureException', 'captureException'],
+    ['captureMessage', 'captureMessage'],
+    ['captureEvent', 'captureEvent'],
+    ['addBreadcrumb', 'addBreadcrumb'],
+    ['setUser', 'setUser'],
+    ['setTags', 'setTags'],
+    ['setExtra', 'setExtra'],
+    ['setContext', 'setContext'],
+    ['getIntegration', 'getIntegration'],
+    ['captureSession', 'captureSession'],
+    ['startSession', 'startSession'],
+    ['endSession', 'endSession'],
+  ]);
+
+  return wrapJscodeshift(j, source, fileName, (j, source) => {
+    const tree = j(source);
+
+    const methodsUsed = new Set();
+
+    let hasChanges = false;
+
+    // Replace getCurrentHub().xxx() and hub.xxx()
+    tree.find(j.CallExpression, { callee: { type: 'MemberExpression' } }).forEach(path => {
+      if (path.value.callee.type !== 'MemberExpression' || path.value.callee.property.type !== 'Identifier') {
+        return;
+      }
+
+      const method = path.value.callee.property.name;
+      const caller = path.value.callee.object;
+      const mapTo = hubMethodMap.get(method);
+
+      const callerIsHubVar = caller.type === 'Identifier' && caller.name.toLocaleLowerCase().includes('hub');
+      const callerIsGetCurrentHub =
+        caller.type === 'CallExpression' &&
+        caller.callee.type === 'Identifier' &&
+        caller.callee.name === 'getCurrentHub';
+      if (callerIsHubVar || callerIsGetCurrentHub) {
+        hasChanges = true;
+        if (mapTo) {
+          methodsUsed.add(mapTo);
+          path.replace(j.callExpression(j.identifier(mapTo), path.value.arguments));
+        } else {
+          addTodoComment(
+            j,
+            path,
+            'Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub'
+          );
+        }
+      }
+    });
+
+    // Replace Sentry.getCurrentHub().xxx()
+    tree
+      .find(j.CallExpression, {
+        callee: {
+          type: 'MemberExpression',
+          object: {
+            type: 'CallExpression',
+            callee: { type: 'MemberExpression', property: { type: 'Identifier', name: 'getCurrentHub' } },
+          },
+        },
+      })
+      .forEach(path => {
+        if (
+          path.value.callee.type !== 'MemberExpression' ||
+          path.value.callee.property.type !== 'Identifier' ||
+          path.value.callee.object.type !== 'CallExpression' ||
+          path.value.callee.object.callee.type !== 'MemberExpression' ||
+          path.value.callee.object.callee.object.type !== 'Identifier'
+        ) {
+          return;
+        }
+
+        const method = path.value.callee.property.name;
+        const mapTo = hubMethodMap.get(method);
+
+        const sentryVar = path.value.callee.object.callee.object;
+
+        hasChanges = true;
+        if (mapTo) {
+          path.replace(j.callExpression(j.memberExpression(sentryVar, j.identifier(mapTo)), path.value.arguments));
+        } else {
+          addTodoComment(
+            j,
+            path,
+            'Could not automatically migrate - see https://github.com/getsentry/sentry-javascript/blob/develop/MIGRATION.md#deprecate-hub'
+          );
+        }
+      });
+
+    if (!hasChanges) {
+      return undefined;
+    }
+
+    const sdk = options.sentry?.sdk;
+    if (sdk) {
+      modifyImports(j, tree, source, sdk, Array.from(methodsUsed), ['getCurrentHub']);
+      dedupeImportStatements(sdk, tree, j);
+    }
+
+    return tree.toSource();
+  });
+};

--- a/test-fixtures/hub/mergeImports.js
+++ b/test-fixtures/hub/mergeImports.js
@@ -1,0 +1,7 @@
+import { getCurrentHub } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
+
+function doSomething() {
+  getCurrentHub().captureException(error);
+  Sentry.getCurrentHub().setUser({ name: 'Anne' });
+}

--- a/test-fixtures/hub/mergeRequire.js
+++ b/test-fixtures/hub/mergeRequire.js
@@ -1,0 +1,7 @@
+const { getCurrentHub } = require('@sentry/browser');
+const Sentry = require('@sentry/browser');
+
+function doSomething() {
+  getCurrentHub().captureException(error);
+  Sentry.getCurrentHub().setUser({ name: 'Anne' });
+}

--- a/test-fixtures/hub/namespaceImport.js
+++ b/test-fixtures/hub/namespaceImport.js
@@ -1,0 +1,6 @@
+import * as Sentry from '@sentry/browser';
+
+function doSomething() {
+  Sentry.getCurrentHub().captureException(error);
+  Sentry.getCurrentHub().setUser({ name: 'Anne' });
+}

--- a/test-fixtures/hub/namespaceRequire.js
+++ b/test-fixtures/hub/namespaceRequire.js
@@ -1,0 +1,6 @@
+const Sentry = require('@sentry/browser');
+
+function doSomething() {
+  Sentry.getCurrentHub().captureException(error);
+  Sentry.getCurrentHub().setUser({ name: 'Anne' });
+}

--- a/test-fixtures/hub/withImports.js
+++ b/test-fixtures/hub/withImports.js
@@ -1,0 +1,33 @@
+import { getCurrentHub } from '@sentry/browser';
+
+function doSomething() {
+  getCurrentHub().captureException(error);
+  getCurrentHub().setUser({ name: 'Anne' });
+  const client = getCurrentHub().getClient();
+  const scope = getCurrentHub().getScope();
+  const isolationScope = getCurrentHub().getIsolationScope();
+  getCurrentHub().captureSession({});
+  getCurrentHub().startSession();
+  getCurrentHub().endSession();
+  getCurrentHub().run(() => {
+    // do something
+  });
+  getCurrentHub().withScope(scope => {
+    // do something
+  });
+  getCurrentHub().setExtra({});
+  getCurrentHub().setContext({});
+  const integration = getCurrentHub().getIntegration('MyIntegration');
+
+  getCurrentHub().bindClient(client);
+  const scope2 = getCurrentHub().pushScope();
+  getCurrentHub().popScope();
+}
+
+function doSomethingElse() {
+  const hub = getCurrentHub();
+  const otherHubHere = getCurrentHub();
+
+  hub.setExtra({});
+  otherHubHere.captureEvent({});
+}

--- a/test-fixtures/hub/withRequire.js
+++ b/test-fixtures/hub/withRequire.js
@@ -1,0 +1,33 @@
+const { getCurrentHub } = require('@sentry/browser');
+
+function doSomething() {
+  getCurrentHub().captureException(error);
+  getCurrentHub().setUser({ name: 'Anne' });
+  const client = getCurrentHub().getClient();
+  const scope = getCurrentHub().getScope();
+  const isolationScope = getCurrentHub().getIsolationScope();
+  getCurrentHub().captureSession({});
+  getCurrentHub().startSession();
+  getCurrentHub().endSession();
+  getCurrentHub().run(() => {
+    // do something
+  });
+  getCurrentHub().withScope(scope => {
+    // do something
+  });
+  getCurrentHub().setExtra({});
+  getCurrentHub().setContext({});
+  const integration = getCurrentHub().getIntegration('MyIntegration');
+
+  getCurrentHub().bindClient(client);
+  const scope2 = getCurrentHub().pushScope();
+  getCurrentHub().popScope();
+}
+
+function doSomethingElse() {
+  const hub = getCurrentHub();
+  const otherHubHere = getCurrentHub();
+
+  hub.setExtra({});
+  otherHubHere.captureEvent({});
+}


### PR DESCRIPTION
We transform most of the hub methods, and add a comment for the ones we can't fix.

This is not perfect, but we do:

1. Replace `getCurrentHub().xxx()`
2. Replace `xxx.getCurrentHub().xxx()`
3. Replace `somethingHub.xxx()` --> heuristic being we look at the variable name including `hub`

This will not cover everything but hopefully most things...

This just rewrites everything to use the global `Sentry.xxx` methods. Which is also not _always_ correct but should be good 95% of the time.