### PR TITLE
feat: Add transform to extract node config into separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ You can run `npx @sentry/migr8 --help` to get a list of available options.
 
 ## Transformations
 
+## Move @sentry/node config into instrument.js file
+
+When using `@sentry/node` in v8, it is required to call `Sentry.init()` before anything else is required/imported.
+Because of this, the recommended way to initialize Sentry is in a separate file (e.g. `instrument.js`) which is
+required/imported at the very top of your application file.
+
+This transform will try to detect this case and create a standalone instrumentation file for you.
+
 ### Add migration comments
 
 There are certain things that migr8 cannot auto-fix for you. This is the case for things like `startTransaction()`,

--- a/src/run.js
+++ b/src/run.js
@@ -105,14 +105,22 @@ export async function runWithTelementry(options) {
 
   await traceStep('run-transformers', async () => {
     for (const transformer of transformers) {
+      const showSpinner = !transformer.requiresUserInput;
+
       const s = spinner();
-      s.start(`Running transformer "${transformer.name}"...`);
+      if (showSpinner) {
+        s.start(`Running transformer "${transformer.name}"...`);
+      }
 
       try {
         await traceStep(transformer.name, () => transformer.transform(files, { ...options, sdk: targetSdk }));
-        s.stop(`Transformer "${transformer.name}" completed.`);
+        if (showSpinner) {
+          s.stop(`Transformer "${transformer.name}" completed.`);
+        }
       } catch (error) {
-        s.stop(`Transformer "${transformer.name}" failed to complete with error:`);
+        if (showSpinner) {
+          s.stop(`Transformer "${transformer.name}" failed to complete with error:`);
+        }
         // eslint-disable-next-line no-console
         console.error(error);
       }

--- a/src/transformers/nodeInstrumentFile/index.js
+++ b/src/transformers/nodeInstrumentFile/index.js
@@ -15,7 +15,7 @@ export default {
   requiresUserInput: true,
   transform: async (files, options) => {
     if (options.sdk !== '@sentry/node') {
-      // this transform only applies to server SDKs
+      // this transform only applies to the Node SDK
       return;
     }
 

--- a/src/transformers/nodeInstrumentFile/index.js
+++ b/src/transformers/nodeInstrumentFile/index.js
@@ -1,0 +1,16 @@
+import path from 'path';
+import url from 'url';
+
+import { runJscodeshift } from '../../utils/jscodeshift.js';
+
+/**
+ * @type {import('types').Transformer}
+ */
+export default {
+  name: 'Move @sentry/node config into instrument.js file',
+  transform: async (files, options) => {
+    const transformPath = path.join(path.dirname(url.fileURLToPath(import.meta.url)), './transform.cjs');
+
+    await runJscodeshift(transformPath, files, options);
+  },
+};

--- a/src/transformers/nodeInstrumentFile/index.js
+++ b/src/transformers/nodeInstrumentFile/index.js
@@ -1,84 +1,45 @@
 import path from 'path';
 import url from 'url';
 
-import { confirm, log, select } from '@clack/prompts';
+import { log } from '@clack/prompts';
 import chalk from 'chalk';
 
 import { runJscodeshift } from '../../utils/jscodeshift.js';
-import { abortIfCancelled } from '../../utils/clackUtils.js';
 
 /**
  * @type {import('types').Transformer}
  */
 export default {
   name: 'Move @sentry/node config into instrument.js file',
-  requiresUserInput: true,
   transform: async (files, options) => {
     if (options.sdk !== '@sentry/node') {
       // this transform only applies to the Node SDK
       return;
     }
 
-    log.info(`Attempting to move your Sentry config into a dedicated ${chalk.cyan('instrument.js')} file.
+    log.info(`Moving your Sentry config into a dedicated ${chalk.cyan('instrument.js')} file.
 
 In version 8, the order of importing and initializing Sentry matters a lot.
-We therefore recommend moving your Sentry initialization into a separate file.
+We therefore move your Sentry initialization into a separate file and import it right on top of your file.
+This ensures correct ordering.
 
 More information: ${chalk.gray('https://docs.sentry.io/platforms/javascript/guides/node/#configure')}`);
 
-    const shouldApplyTransform = await abortIfCancelled(
-      confirm({
-        message: 'Do you want to continue with this change?',
-        active: 'Yes, create the file',
-        inactive: "No, I'll do this myself later.",
-      })
+    log.info(
+      `${chalk.underline(
+        'Important:'
+      )} If you're using EcmaScript Modules (ESM) mode, you need to load the ${chalk.cyan(
+        'instrument.js'
+      )} file differently.
+
+Please read this guide: ${chalk.gray('https://docs.sentry.io/platforms/javascript/guides/node/install/esm')}
+
+After you've done that, remove import of ${chalk.cyan('instrument.js')} from your file(s).
+
+This only applies if you are actually using ESM natively with Node.
+If you use ${chalk.gray('import')} syntax but transpile to CommonJS (e.g. TypeScript), you're all set up already!
+`
     );
-
-    if (!shouldApplyTransform) {
-      log.info('Skipping this change, remember to do it later, this is important!');
-      return;
-    }
-
-    log.info(`Great! I will move your Sentry config into a new file. We're not done though.
-
-We also need to make sure that this file is imported before anything else in your application.
-
-There are two options:
-
-- Run your app with ${chalk.cyan('node --require instrument.js index.js')} CLI argument
-- Import ${chalk.cyan('instrument.js')} on top of your entry point (This will only work in CJS node apps)
-`);
-
-    const shouldInsertImport = await abortIfCancelled(
-      select({
-        message: 'What do you want to do?',
-        options: [
-          {
-            value: false,
-            label: "I'll run my app with the CLI argument",
-            hint: 'Recommended but you need to do this yourself',
-          },
-          {
-            value: true,
-            label: 'Add the import for instrument.js on top of my file',
-            hint: 'Only works in CJS node apps',
-          },
-        ],
-      })
-    );
-
-    if (shouldInsertImport) {
-      log.info('Great! I will add the import for you in the file(s) where you configure Sentry.');
-    } else {
-      log.info(`Great! From now on, make sure to run your app with the following command:
-- ESM: ${chalk.cyan('node --import instrument.js your-app.js')}
-- CJS: ${chalk.cyan('node --require instrument.js your-app.cjs')}`);
-    }
-
-    options.transformOptions = {
-      ...options.transformOptions,
-      'nodeInstrumentFile:add-import': shouldInsertImport,
-    };
 
     const transformPath = path.join(path.dirname(url.fileURLToPath(import.meta.url)), './transform.cjs');
     await runJscodeshift(transformPath, files, options);

--- a/src/transformers/nodeInstrumentFile/index.js
+++ b/src/transformers/nodeInstrumentFile/index.js
@@ -1,16 +1,86 @@
 import path from 'path';
 import url from 'url';
 
+import { confirm, log, select } from '@clack/prompts';
+import chalk from 'chalk';
+
 import { runJscodeshift } from '../../utils/jscodeshift.js';
+import { abortIfCancelled } from '../../utils/clackUtils.js';
 
 /**
  * @type {import('types').Transformer}
  */
 export default {
   name: 'Move @sentry/node config into instrument.js file',
+  requiresUserInput: true,
   transform: async (files, options) => {
-    const transformPath = path.join(path.dirname(url.fileURLToPath(import.meta.url)), './transform.cjs');
+    if (options.sdk !== '@sentry/node') {
+      // this transform only applies to server SDKs
+      return;
+    }
 
+    log.info(`Attempting to move your Sentry config into a dedicated ${chalk.cyan('instrument.js')} file.
+
+In version 8, the order of importing and initializing Sentry matters a lot.
+We therefore recommend moving your Sentry initialization into a separate file.
+
+More information: ${chalk.gray('https://docs.sentry.io/platforms/javascript/guides/node/#configure')}`);
+
+    const shouldApplyTransform = await abortIfCancelled(
+      confirm({
+        message: 'Do you want to continue with this change?',
+        active: 'Yes, create the file',
+        inactive: "No, I'll do this myself later.",
+      })
+    );
+
+    if (!shouldApplyTransform) {
+      log.info('Skipping this change, remember to do it later, this is important!');
+      return;
+    }
+
+    log.info(`Great! I will move your Sentry config into a new file. We're not done though.
+
+We also need to make sure that this file is imported before anything else in your application.
+
+There are two options:
+
+- Run your app with ${chalk.cyan('node --require instrument.js index.js')} CLI argument
+- Import ${chalk.cyan('instrument.js')} on top of your entry point (This will only work in CJS node apps)
+`);
+
+    const shouldInsertImport = await abortIfCancelled(
+      select({
+        message: 'What do you want to do?',
+        options: [
+          {
+            value: false,
+            label: "I'll run my app with the CLI argument",
+            hint: 'Recommended but you need to do this yourself',
+          },
+          {
+            value: true,
+            label: 'Add the import for instrument.js on top of my file',
+            hint: 'Only works in CJS node apps',
+          },
+        ],
+      })
+    );
+
+    if (shouldInsertImport) {
+      log.info('Great! I will add the import for you in the file(s) where you configure Sentry.');
+    } else {
+      log.info(`Great! From now on, make sure to run your app with the following command:
+- ESM: ${chalk.cyan('node --import instrument.js your-app.js')}
+- CJS: ${chalk.cyan('node --require instrument.js your-app.cjs')}`);
+    }
+
+    options.transformOptions = {
+      ...options.transformOptions,
+      'nodeInstrumentFile:add-import': shouldInsertImport,
+    };
+
+    const transformPath = path.join(path.dirname(url.fileURLToPath(import.meta.url)), './transform.cjs');
     await runJscodeshift(transformPath, files, options);
   },
 };

--- a/src/transformers/nodeInstrumentFile/nodeInstrumentFile.test.js
+++ b/src/transformers/nodeInstrumentFile/nodeInstrumentFile.test.js
@@ -1,9 +1,8 @@
-import { afterEach, describe, it } from 'node:test';
-import * as assert from 'node:assert';
 import { rmSync } from 'node:fs';
 
+import { afterEach, describe, it, expect } from 'vitest';
+
 import { fileExists, getDirFileContent, getFixturePath, makeTmpDir } from '../../../test-helpers/testPaths.js';
-import { assertStringEquals } from '../../../test-helpers/assert.js';
 
 import tracingConfigTransformer from './index.js';
 
@@ -18,7 +17,7 @@ describe('transformers | nodeInstrumentFile', () => {
   });
 
   it('has correct name', () => {
-    assert.equal(tracingConfigTransformer.name, 'Move @sentry/node config into instrument.js file');
+    expect(tracingConfigTransformer.name).toEqual('Move @sentry/node config into instrument.js file');
   });
 
   it('works with app without Sentry', async () => {
@@ -26,7 +25,7 @@ describe('transformers | nodeInstrumentFile', () => {
     await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
 
     const actual1 = getDirFileContent(tmpDir, 'app.js');
-    assertStringEquals(actual1, getDirFileContent(`${process.cwd()}/test-fixtures/noSentry`, 'app.js'));
+    expect(actual1).toEqual(getDirFileContent(`${process.cwd()}/test-fixtures/noSentry`, 'app.js'));
   });
 
   it('works with browser SDK', async () => {
@@ -34,11 +33,10 @@ describe('transformers | nodeInstrumentFile', () => {
     await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
 
     const actual1 = getDirFileContent(tmpDir, 'app.js');
-    assertStringEquals(
-      actual1,
+    expect(actual1).toEqual(
       getDirFileContent(`${process.cwd()}/test-fixtures/nodeInstrumentFile/browserApp`, 'app.js')
     );
-    assert.equal(fileExists(tmpDir, 'instrument.js'), false);
+    expect(fileExists(tmpDir, 'instrument.js')).toBe(true);
   });
 
   it('works with existing tracing.js', async () => {
@@ -47,12 +45,10 @@ describe('transformers | nodeInstrumentFile', () => {
 
     const actual1 = getDirFileContent(tmpDir, 'app.js');
     const actual2 = getDirFileContent(tmpDir, 'tracing.js');
-    assertStringEquals(
-      actual1,
+    expect(actual1).toEqual(
       getDirFileContent(`${process.cwd()}/test-fixtures/nodeInstrumentFile/nodeAppTracingFile`, 'app.js')
     );
-    assertStringEquals(
-      actual2,
+    expect(actual2).toEqual(
       getDirFileContent(`${process.cwd()}/test-fixtures/nodeInstrumentFile/nodeAppTracingFile`, 'tracing.js')
     );
   });
@@ -62,15 +58,14 @@ describe('transformers | nodeInstrumentFile', () => {
     await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
 
     const actual1 = getDirFileContent(tmpDir, 'app.mjs');
-    assertStringEquals(
-      actual1,
+    expect(actual1).toEqual(
       `import "./instrument";
 
 // do something now!
 console.log('Hello, World!');`
     );
-    assert.equal(fileExists(tmpDir, 'instrument.mjs'), true);
-    assertStringEquals(
+    expect(fileExists(tmpDir, 'instrument.mjs')).toBe(true);
+    expect(
       getDirFileContent(tmpDir, 'instrument.mjs'),
       `import * as Sentry from '@sentry/node';
 Sentry.init({
@@ -84,8 +79,7 @@ Sentry.init({
     await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
 
     const actual1 = getDirFileContent(tmpDir, 'app.js');
-    assertStringEquals(
-      actual1,
+    expect(actual1).toEqual(
       `import "./instrument";
 import { setTag } from '@sentry/node';
 import { somethingElse } from 'other-package';
@@ -95,8 +89,8 @@ setTag('key', 'value');
 // do something now!
 console.log('Hello, World!', somethingElse.doThis());`
     );
-    assert.equal(fileExists(tmpDir, 'instrument.js'), true);
-    assertStringEquals(
+    expect(fileExists(tmpDir, 'instrument.js')).toBe(true);
+    expect(
       getDirFileContent(tmpDir, 'instrument.js'),
       `import { init, getActiveSpan } from '@sentry/node';
 import { something } from 'other-package';
@@ -116,15 +110,14 @@ init({
     await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
 
     const actual1 = getDirFileContent(tmpDir, 'app.js');
-    assertStringEquals(
-      actual1,
+    expect(actual1).toEqual(
       `require("./instrument");
 
 // do something now!
 console.log('Hello, World!');`
     );
-    assert.equal(fileExists(tmpDir, 'instrument.js'), true);
-    assertStringEquals(
+    expect(fileExists(tmpDir, 'instrument.js')).toBe(true);
+    expect(
       getDirFileContent(tmpDir, 'instrument.js'),
       `const Sentry = require('@sentry/node');
 Sentry.init({
@@ -138,8 +131,7 @@ Sentry.init({
     await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
 
     const actual1 = getDirFileContent(tmpDir, 'app.js');
-    assertStringEquals(
-      actual1,
+    expect(actual1).toEqual(
       `require("./instrument");
 const {
   setTag
@@ -153,8 +145,8 @@ setTag('key', 'value');
 // do something now!
 console.log('Hello, World!', somethingElse.doThis());`
     );
-    assert.equal(fileExists(tmpDir, 'instrument.js'), true);
-    assertStringEquals(
+    expect(fileExists(tmpDir, 'instrument.js')).toBe(true);
+    expect(
       getDirFileContent(tmpDir, 'instrument.js'),
       `const {
   init,
@@ -179,15 +171,14 @@ init({
     await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
 
     const actual1 = getDirFileContent(tmpDir, 'app.ts');
-    assertStringEquals(
-      actual1,
+    expect(actual1).toEqual(
       `import "./instrument";
 
 // do something now!
 console.log('Hello, World!');`
     );
-    assert.equal(fileExists(tmpDir, 'instrument.ts'), true);
-    assertStringEquals(
+    expect(fileExists(tmpDir, 'instrument.ts')).toBe(true);
+    expect(
       getDirFileContent(tmpDir, 'instrument.ts'),
       `import * as Sentry from '@sentry/node';
 Sentry.init({

--- a/src/transformers/nodeInstrumentFile/nodeInstrumentFile.test.js
+++ b/src/transformers/nodeInstrumentFile/nodeInstrumentFile.test.js
@@ -7,29 +7,11 @@ import { fileExists, getDirFileContent, getFixturePath, makeTmpDir } from '../..
 
 import tracingConfigTransformer from './index.js';
 
-/** @type typeof globalThis & { _clackSelectResponse?: unknown } */
-const globalWithClackMock = global;
-
-vi.mock('@clack/prompts', async () => {
-  return {
-    // ...(await importOriginal<typeof import('@clack/prompts')>() ?? {}),
-    // this will only affect "foo" outside of the original module
-    select: vi.fn(async () => globalWithClackMock._clackSelectResponse ?? true),
-    confirm: vi.fn(async () => true),
-    log: {
-      info: vi.fn(),
-      warn: vi.fn(),
-    },
-    isCancel: vi.fn(() => false),
-  };
-});
-
 describe('transformers | nodeInstrumentFile', () => {
   let tmpDir = '';
 
   beforeEach(() => {
     vi.clearAllMocks();
-    globalWithClackMock._clackSelectResponse = undefined;
   });
 
   afterEach(() => {

--- a/src/transformers/nodeInstrumentFile/nodeInstrumentFile.test.js
+++ b/src/transformers/nodeInstrumentFile/nodeInstrumentFile.test.js
@@ -209,18 +209,4 @@ Sentry.init({
 });`
     );
   });
-
-  it("Doesn't add an import/require statement if user selects to run with CLI argument", async () => {
-    globalWithClackMock._clackSelectResponse = false;
-
-    tmpDir = makeTmpDir(getFixturePath('nodeInstrumentFile/nodeAppRequire'));
-    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
-
-    const actual = getDirFileContent(tmpDir, 'app.js');
-    expect(actual).toMatchInlineSnapshot(`
-      "// do something now!
-      console.log('Hello, World!');
-      "
-    `);
-  });
 });

--- a/src/transformers/nodeInstrumentFile/nodeInstrumentFile.test.js
+++ b/src/transformers/nodeInstrumentFile/nodeInstrumentFile.test.js
@@ -1,0 +1,198 @@
+import { afterEach, describe, it } from 'node:test';
+import * as assert from 'node:assert';
+import { rmSync } from 'node:fs';
+
+import { fileExists, getDirFileContent, getFixturePath, makeTmpDir } from '../../../test-helpers/testPaths.js';
+import { assertStringEquals } from '../../../test-helpers/assert.js';
+
+import tracingConfigTransformer from './index.js';
+
+describe('transformers | nodeInstrumentFile', () => {
+  let tmpDir = '';
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { force: true, recursive: true });
+      tmpDir = '';
+    }
+  });
+
+  it('has correct name', () => {
+    assert.equal(tracingConfigTransformer.name, 'Move @sentry/node config into instrument.js file');
+  });
+
+  it('works with app without Sentry', async () => {
+    tmpDir = makeTmpDir(getFixturePath('noSentry'));
+    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.js');
+    assertStringEquals(actual1, getDirFileContent(`${process.cwd()}/test-fixtures/noSentry`, 'app.js'));
+  });
+
+  it('works with browser SDK', async () => {
+    tmpDir = makeTmpDir(getFixturePath('nodeInstrumentFile/browserApp'));
+    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.js');
+    assertStringEquals(
+      actual1,
+      getDirFileContent(`${process.cwd()}/test-fixtures/nodeInstrumentFile/browserApp`, 'app.js')
+    );
+    assert.equal(fileExists(tmpDir, 'instrument.js'), false);
+  });
+
+  it('works with existing tracing.js', async () => {
+    tmpDir = makeTmpDir(getFixturePath('nodeInstrumentFile/nodeAppTracingFile'));
+    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.js');
+    const actual2 = getDirFileContent(tmpDir, 'tracing.js');
+    assertStringEquals(
+      actual1,
+      getDirFileContent(`${process.cwd()}/test-fixtures/nodeInstrumentFile/nodeAppTracingFile`, 'app.js')
+    );
+    assertStringEquals(
+      actual2,
+      getDirFileContent(`${process.cwd()}/test-fixtures/nodeInstrumentFile/nodeAppTracingFile`, 'tracing.js')
+    );
+  });
+
+  it('works with node SDK & simple import', async () => {
+    tmpDir = makeTmpDir(getFixturePath('nodeInstrumentFile/nodeAppImport'));
+    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.mjs');
+    assertStringEquals(
+      actual1,
+      `import "./instrument";
+
+// do something now!
+console.log('Hello, World!');`
+    );
+    assert.equal(fileExists(tmpDir, 'instrument.mjs'), true);
+    assertStringEquals(
+      getDirFileContent(tmpDir, 'instrument.mjs'),
+      `import * as Sentry from '@sentry/node';
+Sentry.init({
+  dsn: 'https://example.com',
+});`
+    );
+  });
+
+  it('works with node SDK & other imports', async () => {
+    tmpDir = makeTmpDir(getFixturePath('nodeInstrumentFile/nodeAppImports'));
+    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.js');
+    assertStringEquals(
+      actual1,
+      `import "./instrument";
+import { setTag } from '@sentry/node';
+import { somethingElse } from 'other-package';
+
+setTag('key', 'value');
+
+// do something now!
+console.log('Hello, World!', somethingElse.doThis());`
+    );
+    assert.equal(fileExists(tmpDir, 'instrument.js'), true);
+    assertStringEquals(
+      getDirFileContent(tmpDir, 'instrument.js'),
+      `import { init, getActiveSpan } from '@sentry/node';
+import { something } from 'other-package';
+init({
+  dsn: 'https://example.com',
+  beforeSend(event) {
+    event.extra.hasSpan = !!getActiveSpan();
+    event.extra.check = something();
+    return event;
+  }
+});`
+    );
+  });
+
+  it('works with node SDK & simple require', async () => {
+    tmpDir = makeTmpDir(getFixturePath('nodeInstrumentFile/nodeAppRequire'));
+    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.js');
+    assertStringEquals(
+      actual1,
+      `require("./instrument");
+
+// do something now!
+console.log('Hello, World!');`
+    );
+    assert.equal(fileExists(tmpDir, 'instrument.js'), true);
+    assertStringEquals(
+      getDirFileContent(tmpDir, 'instrument.js'),
+      `const Sentry = require('@sentry/node');
+Sentry.init({
+  dsn: 'https://example.com',
+});`
+    );
+  });
+
+  it('works with node SDK & other requires', async () => {
+    tmpDir = makeTmpDir(getFixturePath('nodeInstrumentFile/nodeAppRequires'));
+    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.js');
+    assertStringEquals(
+      actual1,
+      `require("./instrument");
+const {
+  setTag
+} = require('@sentry/node');
+const {
+  somethingElse
+} = require('other-package');
+
+setTag('key', 'value');
+
+// do something now!
+console.log('Hello, World!', somethingElse.doThis());`
+    );
+    assert.equal(fileExists(tmpDir, 'instrument.js'), true);
+    assertStringEquals(
+      getDirFileContent(tmpDir, 'instrument.js'),
+      `const {
+  init,
+  getActiveSpan
+} = require('@sentry/node');
+const {
+  something
+} = require('other-package');
+init({
+  dsn: 'https://example.com',
+  beforeSend(event) {
+    event.extra.hasSpan = !!getActiveSpan();
+    event.extra.check = something();
+    return event;
+  }
+});`
+    );
+  });
+
+  it('works with node SDK & typescript', async () => {
+    tmpDir = makeTmpDir(getFixturePath('nodeInstrumentFile/nodeAppTypescript'));
+    await tracingConfigTransformer.transform([tmpDir], { filePatterns: [], sdk: '@sentry/node' });
+
+    const actual1 = getDirFileContent(tmpDir, 'app.ts');
+    assertStringEquals(
+      actual1,
+      `import "./instrument";
+
+// do something now!
+console.log('Hello, World!');`
+    );
+    assert.equal(fileExists(tmpDir, 'instrument.ts'), true);
+    assertStringEquals(
+      getDirFileContent(tmpDir, 'instrument.ts'),
+      `import * as Sentry from '@sentry/node';
+Sentry.init({
+  dsn: 'https://example.com' as string,
+});`
+    );
+  });
+});

--- a/src/transformers/nodeInstrumentFile/transform.cjs
+++ b/src/transformers/nodeInstrumentFile/transform.cjs
@@ -1,0 +1,241 @@
+const path = require('node:path');
+const fs = require('node:fs');
+
+const { wrapJscodeshift } = require('../../utils/dom.cjs');
+const { hasSentryImportOrRequire, getSentryInitExpression } = require('../../utils/jscodeshift.cjs');
+
+/**
+ * Moves Sentry config for `@sentry/node` into a dedicated instrument.js file.
+ *
+ * @param {import('jscodeshift').FileInfo} fileInfo
+ * @param {import('jscodeshift').API} api
+ * @param {import('jscodeshift').Options & { sentry: import('types').RunOptions & {sdk: string} }} options
+ */
+module.exports = function (fileInfo, api, options) {
+  const j = api.jscodeshift;
+  const source = fileInfo.source;
+  const fileName = fileInfo.path;
+
+  return wrapJscodeshift(j, source, fileName, (j, source) => {
+    const tree = j(source);
+
+    const sdk = options.sentry?.sdk;
+
+    // This transform only applies to `@sentry/node` - for others, we do not want to do anything
+    if (sdk !== '@sentry/node' || !hasSentryImportOrRequire(source, sdk)) {
+      return undefined;
+    }
+
+    // If the file is already an instrument.js or similar file, we skip
+    // This is a simple heuristic, but implies that probably the Sentry code is already split out.
+    if (/(instrument)|(tracing)|(sentry)|(trace)(\w|)*\.(\w+)$/i.test(fileName)) {
+      return undefined;
+    }
+
+    const sentryInit = getSentryInitExpression(j, tree, source);
+
+    if (!sentryInit) {
+      return;
+    }
+
+    const sentryInitNode = sentryInit.paths()[0];
+
+    if (!sentryInitNode) {
+      return;
+    }
+
+    const folder = path.dirname(fileName);
+    const extension = path.extname(fileName);
+
+    // Create new file
+    const instrumentFileName = `instrument${extension}`;
+    const instrunmentFilePath = path.join(folder, instrumentFileName);
+
+    // If file already exists, we skip
+    if (fs.existsSync(instrunmentFilePath)) {
+      return undefined;
+    }
+
+    const sentryImport = tree.find(j.ImportDeclaration, { source: { type: 'StringLiteral', value: sdk } });
+
+    const instrumentFile = j(j(j.expressionStatement(sentryInitNode.value)).toSource());
+
+    // Add all imports to the top of the instrument file - we later remove unused imports again
+    tree
+      .find(j.ImportDeclaration)
+      .paths()
+      .reverse()
+      .forEach(path => {
+        instrumentFile.get().node.program.body.unshift(j(path).toSource());
+      });
+
+    // Add all requires to the top of the instrument file - we later remove unused requires again
+    tree
+      .find(j.VariableDeclaration, {
+        declarations: [
+          {
+            type: 'VariableDeclarator',
+            init: {
+              type: 'CallExpression',
+              callee: { type: 'Identifier', name: 'require' },
+            },
+          },
+        ],
+      })
+      .paths()
+      .reverse()
+      .forEach(path => {
+        instrumentFile.get().node.program.body.unshift(j(path).toSource());
+      });
+
+    const instrumentFile2 = j(instrumentFile.toSource());
+    removeUnusedImports(j, instrumentFile2);
+    removeUnusedRequires(j, instrumentFile2);
+
+    fs.writeFileSync(instrunmentFilePath, instrumentFile2.toSource());
+
+    // Add import as first thing
+    // Note: We import/require without file extension, this is the most common way
+    // Potential improvement:
+    // We could check if the file has any relative imports / require and see if that uses file extension
+    if (sentryImport.length > 0) {
+      tree.get().node.program.body.unshift(j.importDeclaration([], j.literal('./instrument')));
+    } else {
+      // Else we add a require
+      const requireStatement = j.callExpression(j.identifier('require'), [j.literal('./instrument')]);
+      tree.get().node.program.body.unshift(j.expressionStatement(requireStatement));
+    }
+
+    // Remove from original file
+    j(sentryInitNode).remove();
+
+    removeUnusedImports(j, tree);
+    removeUnusedRequires(j, tree);
+
+    return tree.toSource();
+  });
+};
+
+/**
+ * Remove any unused imports from the file.
+ *
+ * @param {import('jscodeshift').JSCodeshift} j
+ * @param {import('jscodeshift').Collection} tree
+ */
+function removeUnusedImports(j, tree) {
+  tree.find(j.ImportDeclaration).forEach(path => {
+    const specifiers = path.value.specifiers || [];
+
+    // no specifiers = side-effect import
+    if (specifiers.length === 0) {
+      return;
+    }
+
+    const filtered = specifiers.filter(specifier => {
+      const name = specifier.local?.name;
+      const type = specifier.type;
+
+      if (!name) {
+        return true;
+      }
+
+      return identifierIsUsed(j, tree, name, type);
+    });
+
+    if (filtered.length) {
+      path.value.specifiers = filtered;
+    } else {
+      j(path).remove();
+    }
+  });
+}
+
+/**
+ * Remove any unused requires from the file.
+ *
+ * @param {import('jscodeshift').JSCodeshift} j
+ * @param {import('jscodeshift').Collection} tree
+ */
+function removeUnusedRequires(j, tree) {
+  tree
+    .find(j.VariableDeclaration, {
+      declarations: [
+        {
+          type: 'VariableDeclarator',
+          init: {
+            type: 'CallExpression',
+            callee: { type: 'Identifier', name: 'require' },
+          },
+        },
+      ],
+    })
+    .forEach(path => {
+      const declarations = path.value.declarations;
+
+      // no declarations = side-effect import
+      if (declarations.length === 0) {
+        return;
+      }
+
+      const filtered = declarations.filter(declaration => {
+        const declarationType = declaration.type;
+        if (declarationType !== 'VariableDeclarator') {
+          return true;
+        }
+
+        // default/namespace export
+        const type = declaration.id.type;
+        if (type === 'Identifier') {
+          const name = declaration.id.name;
+          return identifierIsUsed(j, tree, name, declarationType);
+        }
+
+        // destructured import
+        if (type === 'ObjectPattern') {
+          const properties = declaration.id.properties || [];
+          const filteredProperties = properties.filter(property => {
+            if (property.type !== 'ObjectProperty' || property.value.type !== 'Identifier') {
+              return true;
+            }
+
+            const name = property.value.name;
+            return identifierIsUsed(j, tree, name, property.type);
+          });
+
+          if (filteredProperties.length) {
+            declaration.id.properties = filteredProperties;
+            return true;
+          } else {
+            return false;
+          }
+        }
+
+        return true;
+      });
+
+      if (filtered.length) {
+        path.value.declarations = filtered;
+      } else {
+        j(path).remove();
+      }
+    });
+}
+
+/**
+ * Checks if a given identifier is used in the file.
+ *
+ * @param {import('jscodeshift').JSCodeshift} j
+ * @param {import('jscodeshift').Collection} tree
+ * @param {string} name
+ * @param {string} parentType
+ * @returns {boolean}
+ */
+function identifierIsUsed(j, tree, name, parentType) {
+  const usages = tree.find(j.Identifier, { name }).filter(identifier => {
+    const pType = identifier.parentPath.value.type;
+    // Ignore imports themselves
+    return pType !== parentType;
+  });
+
+  return usages.length > 0;
+}

--- a/src/transformers/nodeInstrumentFile/transform.cjs
+++ b/src/transformers/nodeInstrumentFile/transform.cjs
@@ -98,14 +98,12 @@ module.exports = function (fileInfo, api, options) {
     // Note: We import/require without file extension, this is the most common way
     // Potential improvement:
     // We could check if the file has any relative imports / require and see if that uses file extension
-    if (options.sentry.transformOptions?.['nodeInstrumentFile:add-import']) {
-      if (sentryImport.length > 0) {
-        tree.get().node.program.body.unshift(j.importDeclaration([], j.literal('./instrument')));
-      } else {
-        // Else we add a require
-        const requireStatement = j.callExpression(j.identifier('require'), [j.literal('./instrument')]);
-        tree.get().node.program.body.unshift(j.expressionStatement(requireStatement));
-      }
+    if (sentryImport.length > 0) {
+      tree.get().node.program.body.unshift(j.importDeclaration([], j.literal('./instrument')));
+    } else {
+      // Else we add a require
+      const requireStatement = j.callExpression(j.identifier('require'), [j.literal('./instrument')]);
+      tree.get().node.program.body.unshift(j.expressionStatement(requireStatement));
     }
 
     // Remove from original file

--- a/src/transformers/nodeInstrumentFile/transform.cjs
+++ b/src/transformers/nodeInstrumentFile/transform.cjs
@@ -49,10 +49,10 @@ module.exports = function (fileInfo, api, options) {
 
     // Create new file
     const instrumentFileName = `instrument${extension}`;
-    const instrunmentFilePath = path.join(folder, instrumentFileName);
+    const instrumentFilePath = path.join(folder, instrumentFileName);
 
     // If file already exists, we skip
-    if (fs.existsSync(instrunmentFilePath)) {
+    if (fs.existsSync(instrumentFilePath)) {
       return undefined;
     }
 
@@ -92,18 +92,20 @@ module.exports = function (fileInfo, api, options) {
     removeUnusedImports(j, instrumentFile2);
     removeUnusedRequires(j, instrumentFile2);
 
-    fs.writeFileSync(instrunmentFilePath, instrumentFile2.toSource());
+    fs.writeFileSync(instrumentFilePath, instrumentFile2.toSource());
 
     // Add import as first thing
     // Note: We import/require without file extension, this is the most common way
     // Potential improvement:
     // We could check if the file has any relative imports / require and see if that uses file extension
-    if (sentryImport.length > 0) {
-      tree.get().node.program.body.unshift(j.importDeclaration([], j.literal('./instrument')));
-    } else {
-      // Else we add a require
-      const requireStatement = j.callExpression(j.identifier('require'), [j.literal('./instrument')]);
-      tree.get().node.program.body.unshift(j.expressionStatement(requireStatement));
+    if (options.sentry.transformOptions?.['nodeInstrumentFile:add-import']) {
+      if (sentryImport.length > 0) {
+        tree.get().node.program.body.unshift(j.importDeclaration([], j.literal('./instrument')));
+      } else {
+        // Else we add a require
+        const requireStatement = j.callExpression(j.identifier('require'), [j.literal('./instrument')]);
+        tree.get().node.program.body.unshift(j.expressionStatement(requireStatement));
+      }
     }
 
     // Remove from original file

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,12 +7,6 @@ export interface RunOptions {
   sdk?: string;
   cwd?: string;
   disableTelemetry?: boolean;
-  transformOptions?: {
-    /**
-     * Whether to add a top level `import "instrumentation.js"` statement to the file
-     */
-    'nodeInstrumentFile:add-import'?: boolean;
-  };
 }
 
 export interface Transformer {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,6 +7,12 @@ export interface RunOptions {
   sdk?: string;
   cwd?: string;
   disableTelemetry?: boolean;
+  transformOptions?: {
+    /**
+     * Whether to add a top level `import "instrumentation.js"` statement to the file
+     */
+    'nodeInstrumentFile:add-import'?: boolean;
+  };
 }
 
 export interface Transformer {
@@ -15,6 +21,12 @@ export interface Transformer {
    * Will be used in the selection menu or when printing transformer-specific log messages.
    */
   name: string;
+
+  /**
+   * Whether the transformer requires user input to run
+   * If true, the transformer won't show a spinner to avoid cluttering the spinner with user prompts.
+   */
+  requiresUserInput?: boolean;
 
   /**
    * Takes a list of files and applies whatever transformation/modification is necessary

--- a/src/utils/package-json.js
+++ b/src/utils/package-json.js
@@ -15,6 +15,8 @@ export const SENTRY_SDK_PACKAGE_NAMES = [
   '@sentry/serverless',
 
   // Base SDKs
+  '@sentry/deno',
+  '@sentry/bun',
   '@sentry/browser',
   '@sentry/node',
 ];

--- a/test-fixtures/nodeInstrumentFile/browserApp/app.js
+++ b/test-fixtures/nodeInstrumentFile/browserApp/app.js
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: 'https://example.com',
+});
+
+// do something now!
+console.log('Hello, World!');

--- a/test-fixtures/nodeInstrumentFile/nodeAppImport/app.mjs
+++ b/test-fixtures/nodeInstrumentFile/nodeAppImport/app.mjs
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://example.com',
+});
+
+// do something now!
+console.log('Hello, World!');

--- a/test-fixtures/nodeInstrumentFile/nodeAppImports/app.js
+++ b/test-fixtures/nodeInstrumentFile/nodeAppImports/app.js
@@ -1,0 +1,16 @@
+import { init, setTag, getActiveSpan } from '@sentry/node';
+import { something, somethingElse } from 'other-package';
+
+init({
+  dsn: 'https://example.com',
+  beforeSend(event) {
+    event.extra.hasSpan = !!getActiveSpan();
+    event.extra.check = something();
+    return event;
+  }
+});
+
+setTag('key', 'value');
+
+// do something now!
+console.log('Hello, World!', somethingElse.doThis());

--- a/test-fixtures/nodeInstrumentFile/nodeAppRequire/app.js
+++ b/test-fixtures/nodeInstrumentFile/nodeAppRequire/app.js
@@ -1,0 +1,8 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://example.com',
+});
+
+// do something now!
+console.log('Hello, World!');

--- a/test-fixtures/nodeInstrumentFile/nodeAppRequires/app.js
+++ b/test-fixtures/nodeInstrumentFile/nodeAppRequires/app.js
@@ -1,0 +1,16 @@
+const { init, setTag, getActiveSpan } = require('@sentry/node');
+const { something, somethingElse } = require('other-package');
+
+init({
+  dsn: 'https://example.com',
+  beforeSend(event) {
+    event.extra.hasSpan = !!getActiveSpan();
+    event.extra.check = something();
+    return event;
+  }
+});
+
+setTag('key', 'value');
+
+// do something now!
+console.log('Hello, World!', somethingElse.doThis());

--- a/test-fixtures/nodeInstrumentFile/nodeAppTracingFile/app.js
+++ b/test-fixtures/nodeInstrumentFile/nodeAppTracingFile/app.js
@@ -1,0 +1,4 @@
+import './tracing';
+
+// do something now!
+console.log('Hello, World!');

--- a/test-fixtures/nodeInstrumentFile/nodeAppTracingFile/tracing.js
+++ b/test-fixtures/nodeInstrumentFile/nodeAppTracingFile/tracing.js
@@ -1,0 +1,5 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://example.com',
+})

--- a/test-fixtures/nodeInstrumentFile/nodeAppTypescript/app.ts
+++ b/test-fixtures/nodeInstrumentFile/nodeAppTypescript/app.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://example.com' as string,
+});
+
+// do something now!
+console.log('Hello, World!');

--- a/test-helpers/testPaths.js
+++ b/test-helpers/testPaths.js
@@ -43,3 +43,14 @@ export function getDirFileContent(dir, fileName) {
   const fullPath = path.join(dir, fileName);
   return readFileSync(fullPath, 'utf-8');
 }
+/**
+ *
+ *
+ * @param {string} dir
+ * @param {string} fileName
+ * @returns {boolean}
+ */
+export function fileExists(dir, fileName) {
+  const fullPath = path.join(dir, fileName);
+  return existsSync(fullPath);
+}


### PR DESCRIPTION
This transform will try to detect `Sentry.init()` when using `@sentry/node`, and extract it into a separate file `instrument.js` that is required/imported at the very top of the file.