### PR TITLE
feat: Ignore `node_modules` by default for processing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ async function _run() {
     .option('ignoreFilePatterns', {
       alias: 'if',
       describe: 'Glob pattern which files should be ignored',
-      default: [],
+      default: ['node_modules'],
       type: 'string',
       array: true,
     })


### PR DESCRIPTION
@andreiborza noticed this, we should not run on node_modules actually... This is usually covered by leveraging gitignore, but this does not seem to always work when working in a monorepo subpackage. I think adding this as default makes sense.