### PR TITLE
Revert "meta(changelog): Update changelog for 0.2.3"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## 0.2.3
-
-- feat: Ignore `node_modules` by default for processing (#57)
-
 ## 0.2.2
 
 - feat: Ask for SDK selection if auto-detection fails (#53)


### PR DESCRIPTION
Reverts getsentry/sentry-migr8#60 because the release didn't go through.. 😅. Trying again.