### PR TITLE
chore: Switch craft strategy to simple

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,5 +1,5 @@
 minVersion: 0.23.1
-changelogPolicy: auto
+changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
   - name: npm


### PR DESCRIPTION
As discussed [here](https://github.com/getsentry/sentry-migr8/pull/63#issuecomment-2210551564): I'm switching the craft strategy to simple, mimicking how we do it in the sentry-javascript repo, crafting a changelog commit and using `pnpm changelog` to get a changelog.